### PR TITLE
update version of fwrule dependency

### DIFF
--- a/lib/handlers/firewallRules.js
+++ b/lib/handlers/firewallRules.js
@@ -2,7 +2,7 @@
 
 
 const Utils = require('../utils');
-const Formatters = () => require('../formatters'); // circular dep
+const Formatters = () => { return require('../formatters'); }; // circular dep
 
 // eslint-disable-next-line camelcase
 exports.firewall_rule = (fetch, { id }) => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "boom": "7.x.x",
     "bounce": "1.x.x",
     "force-array": "3.1.x",
-    "fwrule": "1.4.x",
+    "fwrule": "2.x.x",
     "graphi": "5.x.x",
     "hasha": "3.0.x",
     "lodash.uniq": "4.5.x",


### PR DESCRIPTION
The unrelated change to `firewallRules.js` was autofixed by the linter.