### PR TITLE
Adds teh test coverages

### DIFF
--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -39,8 +39,8 @@ module.exports = {
     },
 
     metadata: function (root, { name }, request) {
-      const { id: machine } = root;
-      return Handlers.metadata(this.fetch, { machine, name });
+      const { id: machine, metadata } = root;
+      return metadata ? Utils.toNameValues(metadata) : Handlers.metadata(this.fetch, { machine, name });
     },
 
     networks: async function (root, args, request) {

--- a/lib/handlers/firewallRules.js
+++ b/lib/handlers/firewallRules.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const Utils = require('../utils');
 const Formatters = () => { return require('../formatters'); }; // circular dep
 

--- a/lib/handlers/images.js
+++ b/lib/handlers/images.js
@@ -70,6 +70,6 @@ exports.exportImage = async (fetch, { id, manta_path }) => {
     manta_path
   };
 
-  await fetch(`/images/${id}`, { method: 'post', query });
-  return exports.image(fetch, { id });
+  const location = await fetch(`/images/${id}`, { method: 'post', query });
+  return location;
 };

--- a/lib/handlers/machines/index.js
+++ b/lib/handlers/machines/index.js
@@ -32,10 +32,12 @@ exports.machines = async (fetch, { id, brand = '', state = '', tags = [], ...arg
 
   if (brand) {
     brand = brand.toLowerCase();
+    query.brand = brand;
   }
 
   if (state) {
     state = state.toLowerCase();
+    query.state = state;
   }
 
   const { res: { headers } } = await fetch('/machines', {

--- a/lib/handlers/products.js
+++ b/lib/handlers/products.js
@@ -73,8 +73,12 @@ const products = [{
 
 exports.products = (cloudapiUrl = '/') => {
   return products.map((product) => {
-    product.tags = product.tags || [];
-    product.url = product.url || cloudapiUrl;
-    return product;
+    return {
+      name: product.name,
+      description: product.description,
+      category: product.category,
+      tags: product.tags || [],
+      url: product.url || cloudapiUrl
+    };
   });
 };

--- a/lib/schema.graphql
+++ b/lib/schema.graphql
@@ -758,7 +758,7 @@ type Query {
     machine: ID!
     # NIC's MAC address
     mac: String!
-  ): [NIC]
+  ): NIC
 }
 
 type Mutation {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "graphdoc": "graphdoc -s ./lib/schema.graphql -o ./doc --force",
     "lint": "belly-button --fix",
     "pretest": "npm run lint",
-    "test": "lab -t 79 --coverage-path lib -a code"
+    "test": "lab -t 95 --coverage-path lib -a code"
   },
   "dependencies": {
     "apr-map": "3.0.x",
     "boom": "7.2.x",
     "bounce": "1.2.x",
-    "webconsole-cloudapi-client": "1.0.x",
+    "webconsole-cloudapi-client": "1.x.x",
     "force-array": "3.1.x",
     "fwrule": "2.0.x",
     "graphi": "5.6.x",
@@ -37,7 +37,9 @@
     "hapi": "17.x.x",
     "hapi-triton-auth": "2.x.x",
     "inert": "5.x.x",
+    "joi": "13.1.2",
     "lab": "15.x.x",
-    "stand-in": "4.x.x"
+    "stand-in": "4.x.x",
+    "testdouble": "3.7.x"
   }
 }

--- a/test/configs.js
+++ b/test/configs.js
@@ -53,4 +53,33 @@ describe('config', () => {
     expect(res.result.data.config[0].name).to.equal('default_network');
     expect(res.result.data.config[0].value).to.equal('45607081-4cd2-45c8-baf7-79da760fffaa');
   });
+
+  it('can update a config', async () => {
+    const config = {
+      default_network: '45607081-4cd2-45c8-baf7-79da760fffaa'
+    };
+
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', (stand) => {
+      return config;
+    });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/test/graphql',
+      method: 'post',
+      payload: {
+        query: `mutation {
+        updateConfig(
+          default_network: "45607081-4cd2-45c8-baf7-79da760fffaa"
+        ) { id name value } }`
+      }
+    });
+
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.updateConfig).to.exist();
+    expect(res.result.data.updateConfig[0].name).to.equal('default_network');
+    expect(res.result.data.updateConfig[0].value).to.equal('45607081-4cd2-45c8-baf7-79da760fffaa');
+  });
 });

--- a/test/formatters.js
+++ b/test/formatters.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const { expect } = require('code');
+const Lab = require('lab');
+const TestDouble = require('testdouble');
+
+
+const lab = exports.lab = Lab.script();
+const { describe, it, afterEach, beforeEach } = lab;
+
+const request = {
+  plugins: {
+    cloudapi: {}
+  }
+};
+
+
+describe('formatters', () => {
+  let Handlers;
+  // let fetch;
+  let Formatters;
+  beforeEach(() => {
+    Handlers = TestDouble.replace('../lib/handlers', {
+      network: TestDouble.func('network')
+    });
+    // fetch = TestDouble.func('fetch');
+    request.plugins.cloudapi.fetch = () => {};
+    Formatters = require('../lib/formatters');
+  });
+
+  afterEach(() => {
+    TestDouble.reset();
+  });
+
+  it('does the thing', async () => {
+    TestDouble.when(Handlers.network(TestDouble.matchers.anything(), TestDouble.matchers.anything())).thenResolve('it did a thing');
+    const res = await Formatters.NIC.network({ network: '123' }, null, request);
+    expect(res).to.equal('it did a thing');
+  });
+
+  it('can change the image os property value to upper-case', () => {
+    const result = Formatters.Image.os({ os: 'bacon' });
+    expect(result).to.equal('BACON');
+  });
+
+  it('can handle null os image property', () => {
+    const result = Formatters.Image.os({ os: null });
+    expect(result).to.equal(null);
+  });
+
+  it('can change the image state property value to upper-case', () => {
+    const result = Formatters.Image.state({ state: 'crispy' });
+    expect(result).to.equal('CRISPY');
+  });
+
+  it('can handle null state image property', () => {
+    const result = Formatters.Image.state({ state: null });
+    expect(result).to.equal(null);
+  });
+
+  it('can change the image type property value to upper-case and replaces dashes with underscores', () => {
+    const result = Formatters.Image.type({ type: 'salisbury-steak' });
+    expect(result).to.equal('SALISBURY_STEAK');
+  });
+
+  it('can handle null type image property', () => {
+    const result = Formatters.Image.type({ type: null });
+    expect(result).to.equal(null);
+  });
+
+  it('can change action parameters to keyvalue array', () => {
+    const result = Formatters.Action.parameters({ parameters: { bacon: 'crispy'} });
+    expect(result.length).to.equal(1);
+    expect(result[0]).to.contain({name: 'bacon', value: 'crispy'});
+  });
+
+  it('can change the caller type property value to upper-case', () => {
+    const result = Formatters.Caller.type({ type: 'beef-jerky' });
+    expect(result).to.equal('BEEF-JERKY');
+  });
+
+  it('can handle null type caller property', () => {
+    const result = Formatters.Caller.type({ type: null });
+    expect(result).to.equal(null);
+  });
+
+  it('can return Caller.keyId', () => {
+    const result = Formatters.Caller.key_id({ keyId: '42' });
+    expect(result).to.equal('42');
+  });
+
+  it('can change the Snapshot.state value to upper-case', () => {
+    const result = Formatters.Snapshot.state({ state: 'crispy' });
+    expect(result).to.equal('CRISPY');
+  });
+
+  it('can handle null Snapshot.state property', () => {
+    const result = Formatters.Snapshot.state({ state: null });
+    expect(result).to.equal(null);
+  });
+
+  it('can change the Snapshot.id value to what', () => {
+    const result = Formatters.Snapshot.id({ name: '12345' });
+    expect(result).to.equal('3627909a29c31381a071ec27f7c9ca97726182aed29a7ddd2e54353322cfb30abb9e3a6df2ac2c20fe23436311d678564d0c8d305930575f60e2d3d048184d79');
+  });
+
+  it('can change the ImageError.code value to upper-case', () => {
+    const result = Formatters.ImageError.code({ code: 'crispy' });
+    expect(result).to.equal('CRISPY');
+  });
+
+  it('can handle null ImageError.state property', () => {
+    const result = Formatters.ImageError.code({ code: null });
+    expect(result).to.equal(null);
+  });
+
+  it('can change the ImageFile.compression value to upper-case', () => {
+    const result = Formatters.ImageFile.compression({ compression: 'crispy' });
+    expect(result).to.equal('CRISPY');
+  });
+
+  it('can handle null ImageFile.compression property', () => {
+    const result = Formatters.ImageFile.compression({ compression: null });
+    expect(result).to.equal(null);
+  });
+
+  it('can return empty array when network machines fabrics is null', async () => {
+    const result = await Formatters.Network.machines({ fabric: null });
+    expect(result).to.exist();
+    expect(result.length).to.equal(0);
+  });
+});

--- a/test/handlers.js
+++ b/test/handlers.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const { expect } = require('code');
+const Lab = require('lab');
+const Handlers = require('../lib/handlers');
+
+const lab = exports.lab = Lab.script();
+const { describe, it } = lab;
+const Joi = require('joi');
+
+describe('handlers', () => {
+  it('loads up all the handlers', async () => {
+    const schema = Joi.object().keys({
+      config: Joi.func().arity(1),
+      updateConfig: Joi.func().arity(2),
+      datacenter: Joi.func().arity(3),
+      datacenters: Joi.func().arity(1),
+      vlan: Joi.func().arity(2),
+      vlans: Joi.func().arity(2),
+      createVLAN: Joi.func().arity(2),
+      updateVLAN: Joi.func().arity(2),
+      deleteVLAN: Joi.func().arity(2),
+      network: Joi.func().arity(2),
+      networks: Joi.func().arity(2),
+      createNetwork: Joi.func().arity(2),
+      deleteNetwork: Joi.func().arity(2),
+      firewall_rule: Joi.func().arity(2),
+      firewall_rules: Joi.func().arity(1),
+      firewall_rules_create_machine: Joi.func().arity(2),
+      createFirewallRule: Joi.func().arity(2),
+      updateFirewallRule: Joi.func().arity(2),
+      enableFirewallRule: Joi.func().arity(2),
+      disableFirewallRule: Joi.func().arity(2),
+      deleteFirewallRule: Joi.func().arity(2),
+      image: Joi.func().arity(2),
+      images: Joi.func().arity(2),
+      createImageFromMachine: Joi.func().arity(2),
+      updateImage: Joi.func().arity(2),
+      deleteImage: Joi.func().arity(2),
+      exportImage: Joi.func().arity(2),
+      key: Joi.func().arity(2),
+      keys: Joi.func().arity(2),
+      createKey: Joi.func().arity(2),
+      deleteKey: Joi.func().arity(2),
+      enableMachineFirewall: Joi.func().arity(2),
+      disableMachineFirewall: Joi.func().arity(2),
+      metadataValue: Joi.func().arity(2),
+      metadata: Joi.func().arity(2),
+      updateMachineMetadata: Joi.func().arity(2),
+      deleteMachineMetadata: Joi.func().arity(2),
+      deleteAllMachineMetadata: Joi.func().arity(2),
+      nic: Joi.func().arity(2),
+      nics: Joi.func().arity(2),
+      addNic: Joi.func().arity(2),
+      removeNic: Joi.func().arity(2),
+      snapshot: Joi.func().arity(2),
+      snapshots: Joi.func().arity(2),
+      createMachineSnapshot: Joi.func().arity(2),
+      startMachineFromSnapshot: Joi.func().arity(2),
+      deleteMachineSnapshot: Joi.func().arity(2),
+      tag: Joi.func().arity(2),
+      tags: Joi.func().arity(2),
+      addMachineTags: Joi.func().arity(2),
+      replaceMachineTags: Joi.func().arity(2),
+      deleteMachineTag: Joi.func().arity(2),
+      deleteMachineTags: Joi.func().arity(2),
+      machine: Joi.func().arity(2),
+      machines: Joi.func().arity(2),
+      actions: Joi.func().arity(2),
+      stopMachine: Joi.func().arity(2),
+      startMachine: Joi.func().arity(2),
+      rebootMachine: Joi.func().arity(2),
+      resizeMachine: Joi.func().arity(2),
+      renameMachine: Joi.func().arity(2),
+      createMachine: Joi.func().arity(2),
+      deleteMachine: Joi.func().arity(2),
+      packages: Joi.func().arity(2),
+      package: Joi.func().arity(2),
+      policy: Joi.func().arity(2),
+      policies: Joi.func().arity(2),
+      createPolicy: Joi.func().arity(2),
+      updatePolicy: Joi.func().arity(2),
+      deletePolicy: Joi.func().arity(2),
+      products: Joi.func(),
+      rndName: Joi.func().arity(1),
+      rndImageName: Joi.func().arity(1),
+      role: Joi.func().arity(2),
+      roles: Joi.func().arity(2),
+      createRole: Joi.func().arity(2),
+      updateRole: Joi.func().arity(2),
+      deleteRole: Joi.func().arity(2),
+      services: Joi.func().arity(1),
+      account: Joi.func().arity(1),
+      updateAccount: Joi.func().arity(2),
+      user: Joi.func().arity(2),
+      users: Joi.func().arity(2),
+      createUser: Joi.func().arity(2),
+      updateUser: Joi.func().arity(2),
+      changeUserPassword: Joi.func().arity(2),
+      deleteUser: Joi.func().arity(2)
+    });
+
+    const res = await Joi.validate(Handlers, schema, { abortEarly: false });
+    expect(res).to.exist();
+  });
+});

--- a/test/packages.js
+++ b/test/packages.js
@@ -58,7 +58,26 @@ describe('packages', () => {
     expect(res.result.data.packages[0].name).to.equal(packageObj.name);
   });
 
-  it('can get a package', async () => {
+  it('can get all packages filtered by id', async () => {
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', (stand) => {
+      return packageObj;
+    });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/graphql',
+      method: 'post',
+      payload: { query: `query { packages(id: "${packageObj.id}") { id name } }` }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.packages.length).to.equal(1);
+    expect(res.result.data.packages[0].id).to.equal(packageObj.id);
+    expect(res.result.data.packages[0].name).to.equal(packageObj.name);
+  });
+
+  it('can get a package by id', async () => {
     const server = new Hapi.Server();
     StandIn.replaceOnce(CloudApi.prototype, 'fetch', (stand) => {
       return packageObj;
@@ -70,6 +89,24 @@ describe('packages', () => {
       url: '/graphql',
       method: 'post',
       payload: { query: `query { package(id: "${packageObj.id}") { id name } }` }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.package.id).to.equal(packageObj.id);
+    expect(res.result.data.package.name).to.equal(packageObj.name);
+  });
+
+  it('can get a package by name', async () => {
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', (stand) => {
+      return packageObj;
+    });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/graphql',
+      method: 'post',
+      payload: { query: `query { package(name: "${packageObj.name}") { id name } }` }
     });
     expect(res.statusCode).to.equal(200);
     expect(res.result.data.package.id).to.equal(packageObj.id);

--- a/test/policies.js
+++ b/test/policies.js
@@ -53,6 +53,31 @@ describe('policies', () => {
     expect(res.result.data.policies[0].name).to.equal(policies[0].name);
   });
 
+  it('can get all policies filtered by id', async () => {
+    const policy = {
+      id: 'test',
+      name: 'name',
+      rules: ['foo', 'barr'],
+      description: 'description'
+    };
+
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', () => {
+      return policy;
+    });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/graphql',
+      method: 'post',
+      payload: { query: 'query { policies(id: "test") { id, name, rules, description } }' }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.policies).to.exist();
+    expect(res.result.data.policies[0].id).to.equal(policy.id);
+    expect(res.result.data.policies[0].name).to.equal(policy.name);
+  });
 
   it('can get a single policy', async () => {
     const policy = {
@@ -78,5 +103,89 @@ describe('policies', () => {
     expect(res.result.data.policy).to.exist();
     expect(res.result.data.policy.id).to.equal(policy.id);
     expect(res.result.data.policy.name).to.equal(policy.name);
+  });
+
+  it('can create a policy', async () => {
+    const policy = {
+      id: 'bacon',
+      name: 'bacon policy',
+      rules: ['crispy', 'not burnt'],
+      description: 'bacon policy description'
+    };
+
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', () => {
+      return policy;
+    });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/graphql',
+      method: 'post',
+      payload: { query: `mutation { createPolicy(name: "${policy.name}", rules: ["crispy", "not burnt"], description: "${policy.description}") { id, name, rules, description } }` }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.createPolicy).to.exist();
+    expect(res.result.data.createPolicy.id).to.equal(policy.id);
+    expect(res.result.data.createPolicy.name).to.equal(policy.name);
+  });
+
+  it('can update a policy', async () => {
+    const policy = {
+      id: 'bacon',
+      name: 'bacon policy',
+      rules: ['crispy', 'not burnt'],
+      description: 'bacon policy description'
+    };
+
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', (stand, path, options) => {
+      return {
+        id: policy.id,
+        name: policy.name,
+        rules: policy.rules,
+        description: options.payload.description
+      };
+    });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/graphql',
+      method: 'post',
+      payload: { query: `mutation { updatePolicy(id: "${policy.id}", description: "${policy.description} updated") { id, name, rules, description } }` }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.updatePolicy).to.exist();
+    expect(res.result.data.updatePolicy.id).to.equal(policy.id);
+    expect(res.result.data.updatePolicy.name).to.equal(policy.name);
+    expect(res.result.data.updatePolicy.description).to.equal(policy.description + ' updated');
+  });
+
+  it('can delete a policy', async () => {
+    const policy = {
+      id: 'bacon',
+      name: 'bacon policy',
+      rules: ['crispy', 'not burnt'],
+      description: 'bacon policy description'
+    };
+
+    const server = new Hapi.Server();
+    StandIn.replace(CloudApi.prototype, 'fetch', (stand, path, options) => {
+      return policy;
+    }, { stopAfter: 2 });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/graphql',
+      method: 'post',
+      payload: { query: `mutation { deletePolicy(id: "${policy.id}") { id, name, rules, description } }` }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.deletePolicy).to.exist();
+    expect(res.result.data.deletePolicy.id).to.equal(policy.id);
+    expect(res.result.data.deletePolicy.name).to.equal(policy.name);
   });
 });

--- a/test/products.js
+++ b/test/products.js
@@ -10,7 +10,17 @@ const { it, describe } = lab;
 
 
 describe('products()', () => {
-  it('returns a list of available products with the correct URL', () => {
-    expect(products().length).to.be.greaterThan(1);
+  it('returns a list of available products with the default URL', () => {
+    const productList = products();
+    expect(productList.length).to.be.greaterThan(1);
+    expect(productList[0].tags).to.equal([]);
+    expect(productList[0].url).to.equal('/');
+  });
+
+  it('returns a list of available products with the given URL', () => {
+    const productList = products('/test/api');
+    expect(productList.length).to.be.greaterThan(1);
+    expect(productList[0].tags).to.equal([]);
+    expect(productList[0].url).to.equal('/test/api');
   });
 });

--- a/test/roles.js
+++ b/test/roles.js
@@ -76,7 +76,31 @@ describe('roles', () => {
     expect(res.result.data.roles[0].name).to.equal(role.name);
   });
 
-  it('can a single role', async () => {
+  it('can get a single role from calling roles(id)', async () => {
+    const role = {
+      id: 'test',
+      name: 'test'
+    };
+
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', () => {
+      return role;
+    });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/graphql',
+      method: 'post',
+      payload: { query: 'query { roles(id: "test") { id, name } }' }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.roles).to.exist();
+    expect(res.result.data.roles[0].id).to.equal(role.id);
+    expect(res.result.data.roles[0].name).to.equal(role.name);
+  });
+
+  it('can a single role by name', async () => {
     const role = {
       id: 'test',
       name: 'test'
@@ -98,5 +122,134 @@ describe('roles', () => {
     expect(res.result.data.role).to.exist();
     expect(res.result.data.role.id).to.equal(role.id);
     expect(res.result.data.role.name).to.equal(role.name);
+  });
+
+  it('can a single role by id', async () => {
+    const role = {
+      id: 'test',
+      name: 'test'
+    };
+
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', () => {
+      return role;
+    });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/graphql',
+      method: 'post',
+      payload: { query: 'query { role(id: "test") { id, name } }' }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.role).to.exist();
+    expect(res.result.data.role.id).to.equal(role.id);
+    expect(res.result.data.role.name).to.equal(role.name);
+  });
+
+  it('can create a role', async () => {
+    const role = {
+      id: 'test',
+      name: 'test',
+      policies: [ {
+        id: '38de17c4-39e8-48c7-a168-0f58083de860',
+        name: 'test policy',
+        rules: [],
+        description: ''
+      } ],
+      members: [ {
+        id: '3d51f2d5-46f2-4da5-bb04-3238f2f64768',
+        name: 'test member'
+      }]
+    };
+
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', () => {
+      return role;
+    });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/graphql',
+      method: 'post',
+      payload: { query: 'mutation { createRole(name: "test", policies: ["38de17c4-39e8-48c7-a168-0f58083de860"], members: [ "3d51f2d5-46f2-4da5-bb04-3238f2f64768" ]) { id name policies { id name } members { id } } }' }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.createRole).to.exist();
+    expect(res.result.data.createRole.id).to.equal(role.id);
+    expect(res.result.data.createRole.name).to.equal(role.name);
+    expect(res.result.data.createRole.policies[0].id).to.equal(role.policies[0].id);
+  });
+
+  it('can update a role', async () => {
+    const role = {
+      id: 'test',
+      name: 'test',
+      policies: [{
+        id: '38de17c4-39e8-48c7-a168-0f58083de860',
+        name: 'test policy',
+        rules: [],
+        description: ''
+      }],
+      members: [{
+        id: '3d51f2d5-46f2-4da5-bb04-3238f2f64768',
+        name: 'test member'
+      }]
+    };
+
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', () => {
+      return role;
+    });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/graphql',
+      method: 'post',
+      payload: { query: 'mutation { updateRole(id: "test", policies: ["38de17c4-39e8-48c7-a168-0f58083de860"], members: [ "3d51f2d5-46f2-4da5-bb04-3238f2f64768" ]) { id name policies { id name } members { id } } }' }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.updateRole).to.exist();
+    expect(res.result.data.updateRole.id).to.equal(role.id);
+    expect(res.result.data.updateRole.name).to.equal(role.name);
+    expect(res.result.data.updateRole.policies[0].id).to.equal(role.policies[0].id);
+  });
+
+  it('can delete a role', async () => {
+    const role = {
+      id: 'test',
+      name: 'test',
+      policies: [{
+        id: '38de17c4-39e8-48c7-a168-0f58083de860',
+        name: 'test policy',
+        rules: [],
+        description: ''
+      }],
+      members: [{
+        id: '3d51f2d5-46f2-4da5-bb04-3238f2f64768',
+        name: 'test member'
+      }]
+    };
+
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', () => {
+      return role;
+    });
+
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: '/graphql',
+      method: 'post',
+      payload: { query: 'mutation { deleteRole(id: "test") { id name policies { id name } members { id } } }' }
+    });
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.deleteRole).to.exist();
+    expect(res.result.data.deleteRole.id).to.equal(role.id);
+    expect(res.result.data.deleteRole.name).to.equal(role.name);
+    expect(res.result.data.deleteRole.policies[0].id).to.equal(role.policies[0].id);
   });
 });

--- a/test/services.js
+++ b/test/services.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const Path = require('path');
+const { expect } = require('code');
+const Lab = require('lab');
+const Hapi = require('hapi');
+const StandIn = require('stand-in');
+const CloudApiGql = require('../lib/');
+const CloudApi = require('webconsole-cloudapi-client');
+const QueryString = require('querystring');
+
+const lab = exports.lab = Lab.script();
+const { it, describe, afterEach } = lab;
+
+const serviceList = {
+  cloudapi: 'https://us-west-1.api.example.com',
+  docker: 'tcp://us-west-1.docker.example.com',
+  manta: 'https://us-west.manta.example.com'
+};
+
+describe('services', () => {
+  afterEach(() => {
+    StandIn.restoreAll();
+  });
+
+  const register = {
+    plugin: CloudApiGql,
+    options: {
+      keyPath: Path.join(__dirname, 'test.key'),
+      keyId: 'test',
+      apiBaseUrl: 'http://localhost'
+    }
+  };
+
+  it('returns a list of available services', async () => {
+    const server = new Hapi.Server();
+    StandIn.replaceOnce(CloudApi.prototype, 'fetch', (stand) => {
+      return serviceList;
+    });
+
+    const query = QueryString.stringify({ query: 'query { services { id name value } }' });
+    await server.register(register);
+    await server.initialize();
+    const res = await server.inject({
+      url: `/graphql?${query}`
+    });
+
+    expect(res.statusCode).to.equal(200);
+    expect(res.result.data.services).to.exist();
+    expect(res.result.data.services[0].name).to.equal('cloudapi');
+    expect(res.result.data.services[0].value).to.equal('https://us-west-1.api.example.com');
+  });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const { expect } = require('code');
+const Lab = require('lab');
+const Utils = require('../lib/utils');
+
+
+const lab = exports.lab = Lab.script();
+const { describe, it } = lab;
+
+describe('Utils tests', () => {
+  describe('toNameValues', () => {
+    it('can turn a null into an empty array', () => {
+      const res = Utils.toNameValues(null);
+      expect(res).to.equal([]);
+    });
+    it('can turn an object property names into an array', () => {
+      const res = Utils.toNameValues({ test1: 1, test2: 2 });
+      expect(res).to.be.an.array();
+      expect(res.length).to.equal(2);
+      expect(res[0].id).to.be.a.string();
+      expect(res[0].name).to.be.a.string().and.to.equal('test1');
+      expect(res[0].value).to.be.a.number().and.to.equal(1);
+    });
+  });
+
+  describe('fromNameValues', () => {
+    it('can turn a property name array back into an object', () => {
+      const value = { test1: 1, test2: 2 };
+      const res = Utils.fromNameValues(Utils.toNameValues(value));
+      expect(res).to.equal(value);
+    });
+
+    it('can turn a property name array back into an object with prefixes', () => {
+      const value = { test1: 1, test2: 2 };
+      const res = Utils.fromNameValues(Utils.toNameValues(value), 'bacon');
+      expect(res).to.equal({ bacontest1: 1, bacontest2: 2 });
+    });
+
+    it('it parses triton.cns.disable property as JSON', () => {
+      const value = { 'triton.cns.disable': '{"val": true}' };
+      const res = Utils.fromNameValues(Utils.toNameValues(value));
+      expect(res).to.equal({ 'triton.cns.disable': { val: true } });
+    });
+  });
+
+  describe('toPage', () => {
+    it('turns an empty object into a page of nothing', () => {
+      const res = Utils.toPage({});
+      expect(res.offset).to.equal(0);
+      expect(res.limit).to.equal(0);
+      expect(res.results).to.not.exist();
+      expect(res.total).to.equal(0);
+    });
+
+    it('turns a response and payload into a paged response', () => {
+      const res = Utils.toPage(
+        {
+          res: {
+            headers: { 'x-resource-count': 25 }
+          },
+          payload: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+          offset: 5,
+          limit: 10
+        });
+      expect(res.offset).to.equal(5);
+      expect(res.limit).to.equal(10);
+      expect(res.results).to.equal([5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+      expect(res.total).to.equal(25);
+    });
+  });
+});


### PR DESCRIPTION
Apologies for the mass. Adds 87 tests bringing test coverage up from 79% to 95.8%.

* adds firewallRules and formatters tests
* adds tags test coverage
* adds tests for snapshots
* fixes nic() schema to return one nic, adds nics test coverage
* adds fix to formatters so that metadata is only fetched when it is missing
* adds machine metadata tests
* adds machines test coverage
* adds users test coverage
* adds services test coverage
* adds products and roles test coverage
* adds policies test coverage
* adds packages test coverage
* fixes exportImage and adds images test coverage
* adds key test coverage
* adds fabric tests
* adds image tests
* adds tests for configs datacenters
* adds formatter and handler tests
* adds Utils test coverage